### PR TITLE
Цена в качестве "акции", а не "скидки"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # OpenCart Exchange 1C #
 
- Модуль обмена данными с 1С 8.x в формате CommerceML2 для OpenCart
+ Форк модуля обмена данными с 1С 8.x в формате CommerceML2 для OpenCart
+ позволяет выгружать дополнительные цены в акции, вместо скидок, исправлена
+ обработка кавычек в артикулах - possible mysql inhection vulnerability
  
+    modified:   README.md
+    modified:   upload/admin/controller/module/exchange1c.php
+    modified:   upload/admin/language/english/module/exchange1c.php
+    modified:   upload/admin/language/russian/module/exchange1c.php
+    modified:   upload/admin/model/tool/exchange1c.php
+    modified:   upload/admin/view/template/module/exchange1c.tpl
+
+
  * Домашняя страница: http://zenwalker.ru/lab/opencart-exchange1c/
  * Видеоинструкция установки: http://zenwalker.ru/lab/opencart-exchange1c/installation.html
  * Исходные коды: https://github.com/ethernet1/opencart-exchange1c
@@ -9,6 +19,7 @@
 
 ## Возможности ##
  
+ * Выгрузка цен в акции вместо скидок
  * Выгрузка полной иерархии категорий
  * Выгрузка изображений
  * Выгрузка скидок

--- a/upload/admin/controller/module/exchange1c.php
+++ b/upload/admin/controller/module/exchange1c.php
@@ -37,6 +37,7 @@ class ControllerModuleExchange1c extends Controller {
 		$this->data['entry_fill_parent_cats'] = $this->language->get('entry_fill_parent_cats');
 		$this->data['entry_seo_url'] = $this->language->get('entry_seo_url');
 		$this->data['entry_full_log'] = $this->language->get('entry_full_log');
+        $this->data['entry_special_instead_discounts'] = $this->language->get('entry_special_instead_discounts');
 		$this->data['text_yes'] = $this->language->get('text_yes');
 		$this->data['text_no'] = $this->language->get('text_no');
 		$this->data['text_enabled'] = $this->language->get('text_enabled');
@@ -208,6 +209,13 @@ class ControllerModuleExchange1c extends Controller {
 			$this->data['exchange1c_full_log'] = $this->config->get('exchange1c_full_log');
 		}
 
+        if (isset($this->request->post['exchange1c_special_instead_discounts'])) {
+			$this->data['exchange1c_special_instead_discounts'] = $this->request->post['exchange1c_special_instead_discounts'];
+		}
+		else {
+			$this->data['exchange1c_special_instead_discounts'] = $this->config->get('exchange1c_special_instead_discounts');
+		}
+        
 		if (isset($this->request->post['exchange1c_order_status'])) {
 			$this->data['exchange1c_order_status'] = $this->request->post['exchange1c_order_status'];
 		}
@@ -514,8 +522,10 @@ class ControllerModuleExchange1c extends Controller {
 			
 		}
 		else if (strpos($filename, 'offers') !== false) {
-			$exchange1c_price_type = $this->config->get('exchange1c_price_type');
-			$this->model_tool_exchange1c->parseOffers($filename, $exchange1c_price_type, $language_id);
+			$offers_config = array(
+            'price_type' => $this->config->get('exchange1c_price_type'),
+            'special_instead_discounts' =>  $this->config->get('exchange1c_special_instead_discounts'));
+			$this->model_tool_exchange1c->parseOffers($filename, $offers_config, $language_id);
 			
 			if (!$manual) {
 				echo "success\n";

--- a/upload/admin/language/english/module/exchange1c.php
+++ b/upload/admin/language/english/module/exchange1c.php
@@ -38,6 +38,7 @@ $_['entry_flush_attribute']	= 'Flush attributes:';
 $_['entry_fill_parent_cats']	= 'Fill parent categories:';
 $_['entry_seo_url']		= 'Generate SEO URL (depends on <a href="http://opencartforum.ru/files/file/332-deadcow-seo-v21-automod/" target="_blank">Deadcow SEO</a>):';
 $_['entry_full_log']		= 'Enable log';
+$_['entry_special_instead_discounts']		= 'Load prices to special instead of discounts';
 
 $_['entry_order_status']	= 'Uploaded orders status:';
 $_['entry_order_notify']	= 'Notify users of status change:';

--- a/upload/admin/language/russian/module/exchange1c.php
+++ b/upload/admin/language/russian/module/exchange1c.php
@@ -38,6 +38,7 @@ $_['entry_flush_attribute']	= 'Сбрасывать атрибуты:';
 $_['entry_fill_parent_cats']	= 'Заполнять родительские категории:';
 $_['entry_seo_url']		= 'Генерировать SEO URL (требуется модуль <a href="http://opencartforum.ru/files/file/332-deadcow-seo-v21-automod/" target="_blank">Deadcow SEO</a>):';
 $_['entry_full_log']		= 'Включить подробный лог загрузки';
+$_['entry_special_instead_discounts']		= 'Грузить цены в акции вместо скидок';
 
 $_['entry_order_status'] 	= 'Статус выгруженых заказов:';
 $_['entry_order_notify']	= 'Уведомлять пользователей о смене статуса:';

--- a/upload/admin/model/tool/exchange1c.php
+++ b/upload/admin/model/tool/exchange1c.php
@@ -127,8 +127,10 @@ class ModelToolExchange1c extends Model {
 	 *
 	 * @param    string    наименование типа цены
 	 */
-	public function parseOffers($filename, $config_price_type, $language_id) {
-
+	public function parseOffers($filename, $config, $language_id) {
+        
+        $config_price_type = $config['price_type'];
+        $config_special_instead_discounts = $config['special_instead_discounts'];
 		$importFile = DIR_CACHE . 'exchange1c/' . $filename;
 		$xml = simplexml_load_file($importFile);
 		$data = array();
@@ -138,6 +140,9 @@ class ModelToolExchange1c extends Model {
 
 		if ($enable_log)
 			$this->log->write("Начат разбор файла: " . $filename);
+        
+        if ($enable_log)
+			$this->log->write("Режим акции вместо скидок: " . $config_special_instead_discounts);
 
 		if ($xml->ПакетПредложений->ТипыЦен->ТипЦены) {
 			foreach ($xml->ПакетПредложений->ТипыЦен->ТипЦены as $type) {
@@ -148,19 +153,32 @@ class ModelToolExchange1c extends Model {
 		if (!empty($config_price_type) && count($config_price_type) > 0) {
 			$config_price_type_main = array_shift($config_price_type);
 		}
-
-		// Инициализация массива скидок для оптимизации алгоритма
-		if (!empty($config_price_type) && count($config_price_type) > 0) {
-			$discount_price_type = array();
-			foreach ($config_price_type as $obj) {
-				$discount_price_type[$obj['keyword']] = array(
-					'customer_group_id' => $obj['customer_group_id'],
-					'quantity' => $obj['quantity'],
-					'priority' => $obj['priority']
-				); 
-			}
-		} 
-
+        
+        if(!empty($config_special_instead_discounts)){
+            // Инициализация массива акций для оптимизации алгоритма
+            if (!empty($config_price_type) && count($config_price_type) > 0) {
+                $special_price_type = array();
+                foreach ($config_price_type as $obj) {
+                    $special_price_type[$obj['keyword']] = array(
+                        'customer_group_id' => $obj['customer_group_id'],
+                        'priority' => $obj['priority']
+                    ); 
+                }
+            } 
+            
+        } else {
+            // Инициализация массива скидок для оптимизации алгоритма
+            if (!empty($config_price_type) && count($config_price_type) > 0) {
+                $discount_price_type = array();
+                foreach ($config_price_type as $obj) {
+                    $discount_price_type[$obj['keyword']] = array(
+                        'customer_group_id' => $obj['customer_group_id'],
+                        'quantity' => $obj['quantity'],
+                        'priority' => $obj['priority']
+                    ); 
+                }
+            } 
+        }
 		if ($xml->ПакетПредложений->Предложения->Предложение) {
 			foreach ($xml->ПакетПредложений->Предложения->Предложение as $offer) {
 
@@ -189,25 +207,45 @@ class ModelToolExchange1c extends Model {
 							}
 						}
 					}
-
-					// Вторая цена и тд - $discount_price_type
-					if (!empty($discount_price_type) && $offer->Цены->Цена->ИдТипаЦены) {
-						foreach ($offer->Цены->Цена as $price) {
-							$key = $price_types[(string)$price->ИдТипаЦены];
-							if (isset($discount_price_type[$key])) {
-								$value = array(
-									'customer_group_id'	=> $discount_price_type[$key]['customer_group_id'],
-									'quantity'		=> $discount_price_type[$key]['quantity'],
-									'priority'		=> $discount_price_type[$key]['priority'],
-									'price'			=> (float)$price->ЦенаЗаЕдиницу,
-									'date_start'		=> '0000-00-00',
-									'date_end'		=> '0000-00-00'
-								);
-								$data['product_discount'][] = $value;
-								unset($value);
-							}
-						}
-					}
+                    
+                    if(!empty($config_special_instead_discounts)){
+                        // Вторая цена и тд - $discount_price_type
+                        if (!empty($special_price_type) && $offer->Цены->Цена->ИдТипаЦены) {
+                            foreach ($offer->Цены->Цена as $price) {
+                                $key = $price_types[(string)$price->ИдТипаЦены];
+                                if (isset($special_price_type[$key])) {
+                                    $value = array(
+                                        'customer_group_id'	=> $special_price_type[$key]['customer_group_id'],
+                                        'priority'		=> $special_price_type[$key]['priority'],
+                                        'price'			=> (float)$price->ЦенаЗаЕдиницу,
+                                        'date_start'		=> '0000-00-00',
+                                        'date_end'		=> '0000-00-00'
+                                    );
+                                    $data['product_special'][] = $value;
+                                    unset($value);
+                                }
+                            }
+                        }
+                    } else {
+                        // Вторая цена и тд - $discount_price_type
+                        if (!empty($discount_price_type) && $offer->Цены->Цена->ИдТипаЦены) {
+                            foreach ($offer->Цены->Цена as $price) {
+                                $key = $price_types[(string)$price->ИдТипаЦены];
+                                if (isset($discount_price_type[$key])) {
+                                    $value = array(
+                                        'customer_group_id'	=> $discount_price_type[$key]['customer_group_id'],
+                                        'quantity'		=> $discount_price_type[$key]['quantity'],
+                                        'priority'		=> $discount_price_type[$key]['priority'],
+                                        'price'			=> (float)$price->ЦенаЗаЕдиницу,
+                                        'date_start'		=> '0000-00-00',
+                                        'date_end'		=> '0000-00-00'
+                                    );
+                                    $data['product_discount'][] = $value;
+                                    unset($value);
+                                }
+                            }
+                        }
+                    }
 				}
 
 				//Количество
@@ -756,7 +794,7 @@ class ModelToolExchange1c extends Model {
 		}
 		else {
 			// Проверяем, существует ли товар с тем-же артикулом
-			$query = $this->db->query('SELECT product_id FROM `' . DB_PREFIX . 'product` WHERE `sku` = "' . $data['sku'] . '"');
+			$query = $this->db->query('SELECT product_id FROM `' . DB_PREFIX . 'product` WHERE `sku` = "' . mysql_real_escape_string($data['sku']) . '"');
 
 			// Если есть, то обновляем его
 			if ($query->num_rows && $data['sku'] != '') {

--- a/upload/admin/view/template/module/exchange1c.tpl
+++ b/upload/admin/view/template/module/exchange1c.tpl
@@ -170,6 +170,14 @@
                 <input type="checkbox" value="1" id="exchange1c_full_log" name="exchange1c_full_log" <?php echo ($exchange1c_full_log == 1)? 'checked' : ''; ?>>
               </td>
             </tr>
+            
+            <tr>
+              <td><label for="exchange1c_special_instead_discounts"><?php echo $entry_special_instead_discounts; ?></label></td>
+              <td>
+                <input type="checkbox" value="1" id="exchange1c_special_instead_discounts" name="exchange1c_special_instead_discounts" <?php echo ($exchange1c_special_instead_discounts == 1)? 'checked' : ''; ?>>
+              </td>
+            </tr>
+            
           </table>
         </div>
 


### PR DESCRIPTION
В настройки добавлен флаг для выгрузки цены в качестве "акции", а не "скидки".
В витрине будет отображаться перечеркнутая старая цена.
