### PR TITLE
Update exchange1c.php

### DIFF
--- a/upload/admin/model/tool/exchange1c.php
+++ b/upload/admin/model/tool/exchange1c.php
@@ -451,7 +451,7 @@ class ModelToolExchange1c extends Model {
 
 				$data['model'] = $product->Артикул? (string)$product->Артикул : 'не задана';
 				$data['name'] = $product->Наименование? (string)$product->Наименование : 'не задано';
-				$data['weight'] = $product->Вес? (float)$product->Вес : 0;
+				$data['weight'] = $product->Вес? (float)$product->Вес : null;
 				$data['sku'] = $product->Артикул? (string)$product->Артикул : '';
 
 				if ($enable_log)


### PR DESCRIPTION
Если в 1С не указан вес (например УНФ - там вообще такого аттрибута нету), то и не надо его перезаписывать в значение 0, а пусть берется то, которое было указано в OpenCart
